### PR TITLE
fix: Use relative import in __main__.py

### DIFF
--- a/acp/__main__.py
+++ b/acp/__main__.py
@@ -1,2 +1,2 @@
-import cli
+from . import cli
 cli.main()


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError` that occurred when running the package with `python3 -m acp`.

The `acp/__main__.py` script was using an absolute import (`import cli`), which fails to find the module within the package structure in Python 3. This has been changed to a relative import (`from . import cli`) to ensure the module is resolved correctly from within its own package.