### PR TITLE
fix(client): Initialize payload as bytes to fix TypeError

### DIFF
--- a/acp/client.py
+++ b/acp/client.py
@@ -44,7 +44,7 @@ class ACPClient(object):
 	
 	def get_properties(self, prop_names=[]):
 		# solicita a propriedade enviando o nome e um valor "nulo"
-		payload = ""
+		payload = b""
 		for name in prop_names:
 			payload += ACPProperty.compose_raw_element(0, ACPProperty(name))
 		
@@ -90,7 +90,7 @@ class ACPClient(object):
 	
 	
 	def set_properties(self, props_dict={}):
-		payload = ""
+		payload = b""
 		for name, prop in props_dict.items():
 			logging.debug("prop: {0!r}".format(prop))
 			payload += ACPProperty.compose_raw_element(0, prop)


### PR DESCRIPTION
This commit fixes a `TypeError: can only concatenate str (not "bytes") to str` that occurred in the `get_properties` and `set_properties` methods of `ACPClient`.

The error was introduced during a previous refactoring where `ACPProperty.compose_raw_element` was changed to correctly return `bytes`, but the `payload` variable that accumulates these results was still initialized as a `str` (`""`).

This has been corrected by initializing the `payload` variable as bytes (`b""`) in both methods, ensuring that the concatenation is performed on the same type.